### PR TITLE
Fix mojibake in flag emojis by enforcing UTF-8 charset header

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,5 +18,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
     context.locals.session = null;
   }
 
-  return next();
+  const response = await next();
+
+  const contentType = response.headers.get("content-type");
+  if (contentType?.startsWith("text/html") && !contentType.includes("charset")) {
+    response.headers.set("content-type", "text/html; charset=utf-8");
+  }
+
+  return response;
 });


### PR DESCRIPTION
The server was responding with Content-Type: text/html with no
charset, causing some clients/proxies to guess the wrong encoding
and mangle multi-byte UTF-8 characters (e.g. the flag emojis in the
language switcher rendered as ðŸ‡°ðŸ‡¸). Middleware now sets
charset=utf-8 explicitly on HTML responses.