### PR TITLE
Redesign visual system: real typography, fixed tokens, section rhythm

### DIFF
--- a/src/components/cards/ServiceCard.astro
+++ b/src/components/cards/ServiceCard.astro
@@ -54,7 +54,7 @@ const {
   </div>
 
   <!-- Features -->
-  <FeatureList features={features} />
+  <FeatureList features={features} limit={6} />
 
   <!-- CTA Button -->
   <div class="service-card__cta">

--- a/src/components/layouts/Head.astro
+++ b/src/components/layouts/Head.astro
@@ -273,6 +273,7 @@ const finalStructuredData = structuredData || defaultStructuredData;
 
 <!-- DNS Prefetch for Performance -->
 <link rel="dns-prefetch" href="//fonts.googleapis.com" />
+<link rel="dns-prefetch" href="//fonts.gstatic.com" />
 <link rel="dns-prefetch" href="//www.google-analytics.com" />
 <link rel="dns-prefetch" href="//avatars.githubusercontent.com" />
 <link rel="dns-prefetch" href="//api.github.com" />
@@ -281,24 +282,21 @@ const finalStructuredData = structuredData || defaultStructuredData;
 
 <!-- Preconnect to critical third-party origins -->
 <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
   rel="preconnect"
   href="https://avatars.githubusercontent.com"
   crossorigin
 />
 
-<!-- Preload critical resources -->
-<link rel="preload" href={siteMetadata.favicon.icon} as="image" />
+<!-- Typography: Space Grotesk (headings) + Inter (body) -->
 <link
-  rel="preload"
-  href="/fonts/system-ui.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap"
 />
 
-<!-- Early hints for Core Web Vitals -->
-<link rel="modulepreload" href="/_astro/client.js" />
+<!-- Preload critical resources -->
+<link rel="preload" href={siteMetadata.favicon.icon} as="image" />
 
 <!-- Critical CSS inline (for above-the-fold content) -->
 <style is:inline>
@@ -308,7 +306,9 @@ const finalStructuredData = structuredData || defaultStructuredData;
   }
   body {
     margin: 0;
+    background-color: #05060a;
     font-family:
+      "Inter",
       system-ui,
       -apple-system,
       sans-serif;
@@ -323,5 +323,5 @@ const finalStructuredData = structuredData || defaultStructuredData;
 </style>
 
 <!-- Theme Color -->
-<meta name="theme-color" content="#0f172a" />
-<meta name="msapplication-TileColor" content="#0f172a" />
+<meta name="theme-color" content="#05060a" />
+<meta name="msapplication-TileColor" content="#05060a" />

--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -107,9 +107,9 @@ import { getArrowRightIcon } from "@/utils/icons";
                 Collaboration
               </h4>
               <p class="text-secondary max-w-xl leading-relaxed">
-                🤝 Let’s Collaborate Got an idea or project? I can help define
-                the architecture and bring it to production with scalable,
-                secure, and observable practices.
+                Got an idea or project? I can help define the architecture and
+                bring it to production with scalable, secure, and observable
+                practices.
               </p>
             </div>
 

--- a/src/components/sections/Metrics.astro
+++ b/src/components/sections/Metrics.astro
@@ -2,6 +2,7 @@
 import SectionHeader from "@/components/layouts/SectionHeader.astro";
 import Card from "@/components/ui/Card.astro";
 import Badge from "@/components/ui/Badge.astro";
+import { icons } from "@/utils/icons";
 
 type Status = "healthy" | "warning" | "error";
 
@@ -359,7 +360,7 @@ const formatNumber = (num: number) => {
                 class="btn-execute"
                 disabled
               >
-                <span class="btn-icon">▶</span>
+                <span class="btn-icon" set:html={icons.play} />
                 Execute Tool
               </button>
               <button type="button" id="clear-result-btn" class="btn-clear">
@@ -385,6 +386,17 @@ const formatNumber = (num: number) => {
 </section>
 
 <script>
+  // Inline icon set (mirrors src/utils/icons.ts) for HTML generated
+  // client-side, where importing that module isn't wired up.
+  const svgIcons = {
+    settings: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>`,
+    activity: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>`,
+    globe: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path stroke-linecap="round" d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`,
+    barChart: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18M8 17V10m5 7V6m5 11v-4"/></svg>`,
+    alertTriangle: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="m10.29 3.86-8.18 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.89-3.14l-8.18-14a2 2 0 0 0-3.42 0Z"/><path stroke-linecap="round" d="M12 9v4"/><path stroke-linecap="round" d="M12 17h.01"/></svg>`,
+    play: `<svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>`,
+  };
+
   // MCP data cache configuration
   const MCP_CACHE_DURATION_MS = 30 * 1000; // 30 seconds
   const MCP_AUTO_REFRESH_INTERVAL_MS = 30 * 1000; // 30 seconds
@@ -443,15 +455,15 @@ const formatNumber = (num: number) => {
         // Display MCP metrics
         grid.innerHTML = `
           <div class="mcp-metric-card">
-            <div class="metric-icon">🔧</div>
+            <div class="metric-icon">${svgIcons.settings}</div>
             <div class="metric-content">
               <div class="metric-label">Available Tools</div>
               <div class="metric-value">${toolsCount}</div>
             </div>
           </div>
-          
+
           <div class="mcp-metric-card">
-            <div class="metric-icon">⚡</div>
+            <div class="metric-icon">${svgIcons.activity}</div>
             <div class="metric-content">
               <div class="metric-label">API Response</div>
               <div class="metric-value">${duration}ms</div>
@@ -459,7 +471,7 @@ const formatNumber = (num: number) => {
           </div>
 
           <div class="mcp-metric-card">
-            <div class="metric-icon">🌐</div>
+            <div class="metric-icon">${svgIcons.globe}</div>
             <div class="metric-content">
               <div class="metric-label">Connection</div>
               <div class="metric-value">Active</div>
@@ -467,7 +479,7 @@ const formatNumber = (num: number) => {
           </div>
 
           <div class="mcp-metric-card">
-            <div class="metric-icon">📊</div>
+            <div class="metric-icon">${svgIcons.barChart}</div>
             <div class="metric-content">
               <div class="metric-label">Protocol</div>
               <div class="metric-value">MCP v1.0</div>
@@ -478,7 +490,8 @@ const formatNumber = (num: number) => {
         console.error("Failed to load MCP metrics:", error);
         grid.innerHTML = `
           <div class="mcp-metrics-error">
-            <p>⚠️ Unable to load MCP metrics</p>
+            <span class="metric-icon">${svgIcons.alertTriangle}</span>
+            <p>Unable to load MCP metrics</p>
           </div>
         `;
       }
@@ -763,7 +776,8 @@ const formatNumber = (num: number) => {
 
         // Show loading state
         executeBtn.disabled = true;
-        executeBtn.innerHTML = '<span class="btn-icon">⏳</span> Executing...';
+        executeBtn.innerHTML =
+          '<span class="loading-spinner" aria-hidden="true"></span> Executing...';
 
         const startTime = Date.now();
 
@@ -805,7 +819,7 @@ const formatNumber = (num: number) => {
           error instanceof Error ? error.message : String(error);
       } finally {
         executeBtn.disabled = false;
-        executeBtn.innerHTML = '<span class="btn-icon">▶</span> Execute Tool';
+        executeBtn.innerHTML = `<span class="btn-icon">${svgIcons.play}</span> Execute Tool`;
       }
     }
 
@@ -819,7 +833,8 @@ const formatNumber = (num: number) => {
       if (grid) {
         grid.innerHTML = `
           <div class="error-state">
-            <p style="color: #ef4444;">⚠️ ${this.escapeHtml(message)}</p>
+            <span class="metric-icon" style="color: var(--color-error);">${svgIcons.alertTriangle}</span>
+            <p style="color: var(--color-error);">${this.escapeHtml(message)}</p>
           </div>
         `;
       }
@@ -1060,7 +1075,7 @@ const formatNumber = (num: number) => {
   }
 
   .status-error {
-    color: #ef4444;
+    color: var(--color-error);
   }
 
   .status-default {
@@ -1188,7 +1203,7 @@ const formatNumber = (num: number) => {
   }
 
   .mcp-metrics-error {
-    color: #ef4444;
+    color: var(--color-error);
   }
 
   @keyframes spin {
@@ -1412,7 +1427,7 @@ const formatNumber = (num: number) => {
 
   .param-field label.required::after {
     content: " *";
-    color: #ef4444;
+    color: var(--color-error);
   }
 
   .param-field input,
@@ -1534,7 +1549,7 @@ const formatNumber = (num: number) => {
   }
 
   .metric-badge.error {
-    color: #ef4444;
+    color: var(--color-error);
     background: rgba(239, 68, 68, 0.1);
     border-color: rgba(239, 68, 68, 0.3);
   }

--- a/src/components/ui/FeatureList.astro
+++ b/src/components/ui/FeatureList.astro
@@ -4,17 +4,23 @@ import { getCheckmarkIcon } from "@/utils/icons";
 interface Props {
   title?: string;
   features: string[];
+  /** Cap the visible items; the remainder collapses into a "+N more" line
+   * so cards with uneven feature counts don't stretch a shared grid row
+   * into a mostly-empty box. */
+  limit?: number;
 }
 
-const { title = "Includes:", features } = Astro.props;
+const { title = "Includes:", features, limit } = Astro.props;
 const iconHtml = getCheckmarkIcon();
+const visibleFeatures = limit ? features.slice(0, limit) : features;
+const remaining = limit ? features.length - visibleFeatures.length : 0;
 ---
 
 <div class="feature-list">
   <h4 class="feature-list__title">{title}</h4>
   <ul class="feature-list__items">
     {
-      features.map((feature, index) => (
+      visibleFeatures.map((feature, index) => (
         <li class="feature-list__item">
           <div
             class={`feature-list__icon ${index % 2 === 0 ? "feature-list__icon--primary" : "feature-list__icon--secondary"}`}
@@ -23,6 +29,15 @@ const iconHtml = getCheckmarkIcon();
           <span class="feature-list__text">{feature}</span>
         </li>
       ))
+    }
+    {
+      remaining > 0 && (
+        <li class="feature-list__item feature-list__item--more">
+          <span class="feature-list__text feature-list__text--muted">
+            +{remaining} more
+          </span>
+        </li>
+      )
     }
   </ul>
 </div>
@@ -80,5 +95,14 @@ const iconHtml = getCheckmarkIcon();
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-relaxed);
+  }
+
+  .feature-list__item--more {
+    padding-left: calc(1.25rem + var(--space-sm));
+  }
+
+  .feature-list__text--muted {
+    color: var(--color-text-muted);
+    font-style: italic;
   }
 </style>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -21,9 +21,7 @@ html {
 }
 
 body {
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
-    Arial, sans-serif;
+  font-family: var(--font-body);
   font-size: var(--font-size-base);
   line-height: var(--line-height-normal);
   font-weight: var(--font-weight-normal);
@@ -40,18 +38,20 @@ h3,
 h4,
 h5,
 h6 {
+  font-family: var(--font-display);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height-tight);
+  letter-spacing: -0.02em;
   color: var(--color-text-primary);
   margin-bottom: var(--space-sm);
 }
 
 h1 {
-  font-size: var(--font-size-4xl);
+  font-size: var(--font-size-hero);
   margin-bottom: var(--space-md);
 }
 h2 {
-  font-size: var(--font-size-3xl);
+  font-size: var(--font-size-5xl);
   margin-bottom: var(--space-md);
 }
 h3 {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -336,54 +336,6 @@
   height: 2.5rem;
 }
 
-.avatar--xl {
-  width: 5rem;
-  height: 5rem;
-}
-
-/* ============================================
-   Section Headers
-   ============================================ */
-.section-header {
-  margin-bottom: var(--space-3xl);
-  text-align: left;
-}
-
-@media (min-width: 768px) {
-  .section-header {
-    margin-bottom: var(--space-4xl);
-  }
-}
-
-.section-header__title {
-  font-size: var(--font-size-3xl);
-  font-weight: var(--font-weight-extrabold);
-  letter-spacing: -0.02em;
-  line-height: 1.1;
-  background: linear-gradient(
-    135deg,
-    var(--color-text-primary) 0%,
-    var(--color-text-secondary) 100%
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin-bottom: var(--space-sm);
-}
-
-@media (min-width: 768px) {
-  .section-header__title {
-    font-size: var(--font-size-4xl);
-  }
-}
-
-.section-header__subtitle {
-  font-size: var(--font-size-lg);
-  color: var(--color-text-secondary);
-  max-width: 60ch;
-  line-height: 1.6;
-}
-
 /* ============================================
    📋 Project Cards Component Styles
    ============================================ */
@@ -1020,246 +972,6 @@
   border-radius: var(--radius-lg);
 }
 
-.pricing-card {
-  position: relative;
-  overflow: visible;
-  min-height: 520px;
-  display: flex;
-  flex-direction: column;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  padding: var(--space-2xl) var(--space-xl) var(--space-xl) var(--space-xl);
-  border-radius: var(--radius-2xl);
-  margin-top: var(--space-lg);
-}
-
-.pricing-card:hover {
-  transform: translateY(-8px);
-  box-shadow:
-    0 20px 60px rgba(0, 0, 0, 0.3),
-    0 0 40px rgba(42, 143, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.pricing-card--popular {
-  position: relative;
-  border: 2px solid rgba(42, 143, 255, 0.3);
-  transform: scale(1.03);
-  box-shadow: 0 10px 40px rgba(42, 143, 255, 0.15);
-}
-
-.pricing-card--popular:hover {
-  transform: scale(1.03) translateY(-8px);
-  box-shadow:
-    0 25px 70px rgba(42, 143, 255, 0.25),
-    0 0 60px rgba(42, 143, 255, 0.15);
-  border-color: rgba(42, 143, 255, 0.5);
-}
-
-.pricing-card__header {
-  flex: 0 0 auto;
-  padding-bottom: var(--space-xl);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  margin-bottom: var(--space-md);
-}
-
-.pricing-card__features {
-  flex: 1 1 auto;
-  padding: var(--space-lg) 0;
-  display: flex;
-  flex-direction: column;
-  margin-bottom: var(--space-md);
-}
-
-.pricing-card__features ul {
-  flex: 1;
-}
-
-.pricing-card__cta {
-  flex: 0 0 auto;
-  padding-top: var(--space-lg);
-  margin-top: auto;
-}
-
-/* Popular badge positioning */
-.pricing-card__badge {
-  position: absolute;
-  top: -16px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 20;
-  animation: badgePulse 3s ease-in-out infinite;
-  white-space: nowrap;
-}
-
-.pricing-card:hover .pricing-card__badge {
-  animation-play-state: paused;
-  transform: translateX(-50%) scale(1.1);
-}
-
-@keyframes badgePulse {
-  0%,
-  100% {
-    transform: translateX(-50%) scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: translateX(-50%) scale(1.03);
-    opacity: 0.9;
-  }
-}
-
-/* Header styles */
-.pricing-card__header {
-  text-align: center;
-  padding-top: var(--space-md);
-  position: relative;
-  transition: all 0.3s ease;
-}
-
-.pricing-card:hover .pricing-card__header {
-  transform: translateY(-2px);
-}
-
-.pricing-card__title {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary);
-  margin: var(--space-md) 0 var(--space-lg) 0;
-  line-height: 1.2;
-}
-
-.pricing-card__price {
-  margin: var(--space-lg) 0;
-}
-
-.pricing-card__price-amount {
-  font-size: var(--font-size-4xl);
-  font-weight: var(--font-weight-black);
-  color: var(--color-primary);
-  margin-bottom: var(--space-xs);
-}
-
-.pricing-card__price-period {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-.pricing-card__description {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
-  line-height: 1.6;
-  margin-top: var(--space-md);
-}
-
-/* Features styles */
-.pricing-card__features-title {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-primary);
-  margin-bottom: var(--space-lg);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  text-align: center;
-}
-
-.pricing-card__features-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  text-align: left;
-}
-
-.pricing-card__feature {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-md);
-  margin-bottom: var(--space-md);
-  padding: var(--space-xs) 0;
-  opacity: 0.9;
-  transition: all 0.3s ease;
-  border-radius: var(--radius-md);
-}
-
-.pricing-card:hover .pricing-card__feature {
-  opacity: 1;
-  transform: translateX(4px);
-}
-
-.pricing-card__feature:last-child {
-  margin-bottom: 0;
-}
-
-.pricing-card__feature-icon {
-  flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 2px;
-  color: white;
-}
-
-.pricing-card__feature-icon--primary {
-  background-color: var(--color-primary);
-}
-
-.pricing-card__feature-icon--secondary {
-  background-color: var(--color-secondary);
-}
-
-.pricing-card__feature-text {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
-  line-height: 1.6;
-  flex: 1;
-}
-
-/* Pricing Grid Layout */
-.pricing-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: var(--space-xl);
-  align-items: stretch;
-  margin: var(--space-3xl) 0;
-}
-
-/* Mobile responsive adjustments */
-@media (max-width: 768px) {
-  .pricing-section {
-    padding: var(--space-3xl) 0 var(--space-4xl) 0;
-  }
-
-  .pricing-card {
-    min-height: auto;
-    padding: var(--space-xl) var(--space-lg) var(--space-lg) var(--space-lg);
-    margin-top: var(--space-md);
-  }
-
-  .pricing-card--popular {
-    transform: none;
-    margin-top: var(--space-lg);
-  }
-
-  .pricing-card--popular:hover {
-    transform: translateY(-4px);
-  }
-
-  .pricing-card__badge {
-    top: -10px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .pricing-grid {
-    grid-template-columns: repeat(3, 1fr);
-    max-width: 1200px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-}
-
 .avatar--xl {
   width: 4rem;
   height: 4rem;
@@ -1275,6 +987,7 @@
 }
 
 .section-header__title {
+  font-family: var(--font-display);
   font-size: var(--font-size-4xl);
   font-weight: var(--font-weight-extrabold);
   margin-bottom: var(--space-md);
@@ -1284,6 +997,13 @@
   -webkit-text-fill-color: transparent;
   color: transparent;
   line-height: var(--line-height-tight);
+  letter-spacing: -0.02em;
+}
+
+/* The page's single H1 (hero) reads larger than H2/H3 section titles */
+h1.section-header__title {
+  font-size: var(--font-size-hero);
+  letter-spacing: -0.03em;
 }
 
 .section-header__subtitle {
@@ -1321,15 +1041,11 @@
   }
 }
 
-/* ========== FORM CONTROLS ========== */
+/* ========== FORMS ========== */
 .form-group {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
-}
-
-/* ========== FORMS ========== */
-.form-group {
   position: relative;
 }
 
@@ -1429,8 +1145,6 @@
   }
 }
 
-/* Note: Main pricing card styles are defined above in the component section */
-
 /* ========== RESPONSIVE ADJUSTMENTS ========== */
 @media (max-width: 768px) {
   .card {
@@ -1455,75 +1169,11 @@
   .section-header__title {
     font-size: var(--font-size-3xl);
   }
-
-  .pricing-card--popular {
-    transform: none;
-  }
-
-  .pricing-card--popular:hover {
-    transform: translateY(-4px);
-  }
 }
 
-/* ============================================
-   Services & Contact Sections
-   ============================================ */
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
-.form-label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-secondary);
-  margin-left: 2px;
-}
-
-.form-input {
-  width: 100%;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: var(--radius-lg);
-  padding: var(--space-sm) var(--space-md);
-  color: var(--color-text-primary);
-  font-size: var(--font-size-base);
-  transition: all 0.2s ease;
-}
-
-.form-textarea {
-  resize: vertical;
-  min-height: 120px;
-}
-
+/* Subtle hover polish for text inputs (kept separate from the focus/aria
+   rules above so it only adds a hover affordance, not a duplicate ruleset) */
 .form-input:hover {
   border-color: rgba(255, 255, 255, 0.2);
   background: rgba(255, 255, 255, 0.05);
-}
-
-.form-input:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  background: rgba(42, 143, 255, 0.05);
-  box-shadow: 0 0 0 4px rgba(42, 143, 255, 0.1);
-}
-
-.form-input::placeholder {
-  color: var(--color-text-muted);
-  opacity: 0.7;
-}
-
-.form-error {
-  color: var(--color-error);
-  font-size: var(--font-size-xs);
-  margin-top: 2px;
-  min-height: 1.2em;
-}
-
-.form-status {
-  margin-top: var(--space-md);
-  font-size: var(--font-size-sm);
-  min-height: 1.5em;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -52,15 +52,32 @@ section:first-child {
   padding-bottom: var(--space-3xl);
 }
 
-/* Pricing section specific */
-.pricing-section {
-  padding: var(--space-4xl) 0 var(--space-5xl) 0;
-  background: linear-gradient(
-    135deg,
-    rgba(5, 6, 10, 0.95) 0%,
-    rgba(5, 6, 10, 0.98) 50%,
-    rgba(5, 6, 10, 0.95) 100%
+/* ========================================
+   Section background rhythm
+   A long single-scroll homepage reads as one blurred surface unless each
+   section has its own subtle identity. Alternate a raised surface tone
+   and a soft two-color mesh so sections stay legible as distinct units.
+   ======================================== */
+#about,
+#metrics,
+#contact {
+  background: var(--gradient-mesh), var(--color-background);
+}
+
+#skills,
+#services {
+  background: var(--color-surface);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+#projects {
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    rgba(255, 255, 255, 0.05) 1px,
+    transparent 0
   );
+  background-size: 24px 24px;
 }
 
 /* Header styles */
@@ -283,42 +300,6 @@ section:first-child {
     max-width: 1400px;
     margin-left: auto;
     margin-right: auto;
-  }
-}
-
-/* Pricing grid */
-.pricing-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-  gap: var(--space-3xl);
-  max-width: 1400px;
-  margin: var(--space-4xl) auto;
-  align-items: start;
-  padding: var(--space-xl) var(--space-lg);
-}
-
-@media (max-width: 768px) {
-  .pricing-grid {
-    grid-template-columns: 1fr;
-    gap: var(--space-2xl);
-    margin: var(--space-3xl) auto;
-    padding: var(--space-lg) var(--space-md);
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1024px) {
-  .pricing-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--space-2xl);
-    max-width: 900px;
-    padding: var(--space-xl) var(--space-md);
-  }
-}
-
-@media (min-width: 1024px) {
-  .pricing-grid {
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-3xl);
   }
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -6,8 +6,12 @@
   /* Color Palette */
   --color-primary: #2a8fff;
   --color-primary-hover: #1467c8;
+  --color-primary-rgb: 42, 143, 255;
   --color-secondary: #22b07e;
   --color-secondary-hover: #0d8e5f;
+  --color-secondary-rgb: 34, 176, 126;
+  --color-accent: #d946ef;
+  --color-accent-rgb: 217, 70, 239;
 
   /* Neutral Colors */
   --color-background: #05060a;
@@ -23,6 +27,7 @@
   --color-success: #22c55e;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
+  --color-error-rgb: 239, 68, 68;
 
   /* Spacing Scale */
   --space-2xs: 0.125rem; /* 2px */
@@ -45,6 +50,13 @@
   --radius-full: 9999px;
 
   /* Typography */
+  --font-display:
+    "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-body:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono:
+    ui-monospace, "SF Mono", "Monaco", "Cascadia Code", "Roboto Mono", monospace;
+
   --font-size-2xs: 0.625rem; /* 10px */
   --font-size-xs: 0.75rem; /* 12px */
   --font-size-sm: 0.875rem; /* 14px */
@@ -54,6 +66,9 @@
   --font-size-2xl: 1.5rem; /* 24px */
   --font-size-3xl: 1.875rem; /* 30px */
   --font-size-4xl: 2.25rem; /* 36px */
+  --font-size-5xl: clamp(2.5rem, 2rem + 2.2vw, 3.25rem); /* ~40-52px */
+  --font-size-6xl: clamp(2.75rem, 2rem + 3.2vw, 4rem); /* ~44-64px */
+  --font-size-hero: clamp(2.75rem, 2rem + 3.5vw, 4.5rem); /* hero H1 */
 
   --font-weight-normal: 400;
   --font-weight-medium: 500;
@@ -73,6 +88,10 @@
     0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --shadow-xl:
     0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --shadow-glow-primary:
+    0 8px 24px -6px rgba(var(--color-primary-rgb), 0.45);
+  --shadow-glow-secondary:
+    0 8px 24px -6px rgba(var(--color-secondary-rgb), 0.4);
 
   /* Transitions */
   --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -102,6 +121,46 @@
     rgba(11, 15, 22, 0.95),
     rgba(14, 20, 27, 0.9)
   );
+  --gradient-mesh: radial-gradient(
+      at 20% 0%,
+      rgba(var(--color-primary-rgb), 0.16) 0px,
+      transparent 50%
+    ),
+    radial-gradient(
+      at 80% 15%,
+      rgba(var(--color-secondary-rgb), 0.12) 0px,
+      transparent 50%
+    );
+
+  /* ----------------------------------------------------------------
+     Compatibility aliases
+     A handful of components reference these token names directly;
+     keep them mapped to the canonical tokens above so every surface
+     resolves to the real design system instead of silently falling
+     back to unstyled defaults.
+     ---------------------------------------------------------------- */
+  --surface-primary: var(--color-surface);
+  --surface-secondary: var(--color-surface-raised);
+  --surface-color: var(--color-surface);
+  --surface-hover: rgba(255, 255, 255, 0.05);
+  --border-color: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(255, 255, 255, 0.2);
+  --text-primary: var(--color-text-primary);
+  --text-secondary: var(--color-text-secondary);
+  --text-muted: var(--color-text-muted);
+  --color-text-tertiary: var(--color-text-muted);
+  --accent-primary: var(--color-primary);
+  --accent-color: var(--color-primary);
+  --color-primary-dark: var(--color-primary-hover);
+  --color-bg-primary: var(--color-background);
+  --color-bg-secondary: var(--color-surface);
+  --color-bg-tertiary: var(--color-surface-raised);
+  --color-bg-hover: rgba(255, 255, 255, 0.05);
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-code-js: #f0d264;
+  --color-code-json: #7ee6c0;
+  --color-code-python: #6fb8ff;
+  --color-code-bash: #b7c6d8;
 }
 
 /* Unified dark theme - removed light mode overrides to ensure consistent appearance across all devices */

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -21,6 +21,10 @@ export const icons = {
   map: `<svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657 13.414 20.9a2 2 0 0 1-2.828 0l-4.243-4.243a8 8 0 1 1 11.314 0Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/></svg>`,
   linkedin: `<svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M4.98 3.5c0 1.38-1.11 2.5-2.48 2.5S.02 4.88.02 3.5C.02 2.12 1.13 1 2.5 1s2.48 1.12 2.48 2.5ZM.5 8h4.9v13.5H.5V8Zm7.48 0H12.7l.02 1.85h.09c.59-1.07 2.04-2.15 4.2-2.15 4 0 4.98 2.38 4.98 6.53V21.5h-4.9v-6.29c0-1.5-.03-3.44-2.18-3.44-2.18 0-2.51 1.63-2.51 3.32v6.41H7.98V8Z"/></svg>`,
   "code-lg": `<svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="m7 8-4 4 4 4m10-8 4 4-4 4m-6 6 2-20"/></svg>`,
+  globe: `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path stroke-linecap="round" d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>`,
+  "bar-chart": `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18M8 17V10m5 7V6m5 11v-4"/></svg>`,
+  "alert-triangle": `<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="m10.29 3.86-8.18 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.89-3.14l-8.18-14a2 2 0 0 0-3.42 0Z"/><path stroke-linecap="round" d="M12 9v4"/><path stroke-linecap="round" d="M12 17h.01"/></svg>`,
+  play: `<svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>`,
 } as const;
 
 export type IconName = keyof typeof icons;


### PR DESCRIPTION
- Load Space Grotesk (headings) + Inter (body) via Google Fonts, replacing
  the plain system-font stack and a dead /fonts/system-ui.woff2 preload
- Add a compatibility alias block in variables.css so components that
  referenced undefined tokens (Pagination, LanguageSwitcher, StaticPage,
  ProjectsCatalog, Metrics, the api-explorer subtree) resolve to real
  colors/surfaces instead of silently falling back to unstyled defaults
- Bigger, responsive (clamp-based) heading scale, with the page's single
  H1 reading as a true hero rather than sharing size with H2/H3 sections
- Give each homepage section its own subtle background treatment (mesh
  gradient / raised surface tint / dot pattern) so a long single-scroll
  page reads as distinct sections instead of one blurred surface
- Remove ~300 lines of dead CSS: an unused pricing-card component system,
  and duplicate .section-header/.avatar--xl/.form-group rulesets that
  were silently overriding each other
- Replace emoji icons (Metrics widget, About CTA) with the site's SVG
  icon system for visual consistency
- Fix a real layout bug: service cards with very different feature-list
  lengths (8-12 items) stretched to equal grid-row height, leaving huge
  blank gaps in shorter cards; FeatureList now supports a `limit` prop
  with a "+N more" affordance, matching the pattern already used by
  ProjectCard's tech-stack overflow
- Remove a hardcoded, always-404ing modulepreload for /_astro/client.js

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DtKTM9xpZSsKYTRWofnQ27